### PR TITLE
Double Quote file paths for windows path with spaces

### DIFF
--- a/lib/pdf_forms/pdf.rb
+++ b/lib/pdf_forms/pdf.rb
@@ -1,20 +1,20 @@
 module PdfForms
   class Pdf
     attr_reader :path
-    
+
     def initialize(path, pdftk)
       @path = path
       @pdftk = pdftk
     end
-    
+
     def fields
       @fields ||= read_fields
     end
-    
+
     protected
-    
+
     def read_fields
-      field_output = @pdftk.call_pdftk "'#{path}'", 'dump_data_fields'
+      field_output = @pdftk.call_pdftk %Q("#{path}"), 'dump_data_fields'
       @fields = field_output.split(/^---\n/).map do |field_text|
         if field_text =~ /^FieldName: (\w+)$/
           $1

--- a/lib/pdf_forms/pdftk_wrapper.rb
+++ b/lib/pdf_forms/pdftk_wrapper.rb
@@ -2,46 +2,46 @@ require 'tempfile'
 module PdfForms
   # Wraps calls to PdfTk
   class PdftkWrapper
-    
+
     attr_reader :pdftk, :options
-    
+
     # PdftkWrapper.new('/usr/bin/pdftk', :encrypt => true, :encrypt_options => 'allow Printing')
     def initialize(pdftk_path, options = {})
       @pdftk = pdftk_path
       @options = options
     end
-    
+
     # pdftk.fill_form '/path/to/form.pdf', '/path/to/destination.pdf', :field1 => 'value 1'
     def fill_form(template, destination, data = {})
       fdf = Fdf.new(data)
       tmp = Tempfile.new('pdf_forms-fdf')
       tmp.close
       fdf.save_to tmp.path
-      call_pdftk "'#{template}'", 'fill_form', tmp.path, 'output', destination, 'flatten', encrypt_options(tmp.path)
+      call_pdftk %Q("#{template}"), 'fill_form', tmp.path, 'output', destination, 'flatten', encrypt_options(tmp.path)
       tmp.unlink
     end
-    
+
     # pdftk.read '/path/to/form.pdf'
     # returns an instance of PdfForms::Pdf representing the given template
     def read(path)
       Pdf.new path, self
     end
-    
+
     def get_field_names(template)
       read(template).fields
     end
-    
+
     def call_pdftk(*args)
       %x{#{pdftk} #{args.flatten.compact.join ' '}}
     end
-    
+
     protected
-    
+
     def encrypt_options(pwd)
       if options[:encrypt]
         ['encrypt_128bit', 'owner_pw', pwd, options[:encrypt_options]]
       end
     end
-    
+
   end
 end


### PR DESCRIPTION
On windows, files with spaces need a double quote to make sure it is one argument. So changed the quoting from single quote to double quote
