### PR TITLE
Add require 'pdf_forms' to readme 

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -10,6 +10,7 @@ Fill out PDF forms with pdftk (http://www.accesspdf.com/pdftk/).
 
 === FDF creation
 
+  require 'pdf_forms'
   fdf = PdfForms::Fdf.new :key => 'value', :other_key => 'other value'
   # use to_fdf if you just want the fdf data, without writing it to a file
   puts fdf.to_fdf
@@ -20,6 +21,8 @@ Fill out PDF forms with pdftk (http://www.accesspdf.com/pdftk/).
 
 First get pdftk from http://www.accesspdf.com/pdftk/ and install it.
 
+  require 'pdf_forms'
+  
   # adjust the pdftk path to suit your pdftk installation
   pdftk = PdfForms.new('/usr/local/bin/pdftk')
   


### PR DESCRIPTION
Hello,

This is a wonderful library and thank you so much for creating it!  I have spent several days researching a simple way to fill in pdf forms and everyone on the internet seems to think prawn is the best tool for that (it is not).

Anyway, I think you should add this explicit require to the readme since the gem name and the require name differ. It took me a few minutes to figure this out and I eventually had to look it up in the test_helper.  A minor nitpick, but I think it will help out new people trying to use the gem for the first time.

thanks again
