### PR TITLE
Added additional field attributes

### DIFF
--- a/lib/pdf_forms/field.rb
+++ b/lib/pdf_forms/field.rb
@@ -9,19 +9,25 @@ module PdfForms
     # FieldJustification: Left
     # FieldStateOption: Ja
     # FieldStateOption: Off
+    #
+    # Represenation of a PDF Form Field
     def initialize(field_description)
       field_description.each_line do |line|
         case line
-        when /FieldType:\s*(.+?)\s*$/
-          @type = $1
-        when /FieldName:\s*(.+?)\s*$/
-          @name = $1
         when /FieldStateOption:\s*(.*?)\s*$/
           (@options ||= []) << $1
+        else
+          key, value = line.chomp.split(':').map(&:strip)
+          var_name = key.gsub(/Field/, '').downcase
+          unless self.respond_to?(var_name)
+            self.class.send(:define_method, var_name.to_sym, Proc.new{ instance_variable_get("@#{var_name}".to_sym) } ) # in case new or unknown fields crop up...
+          end
+          instance_variable_set("@#{key.gsub(/Field/, '').downcase}".to_sym, value)
         end
       end
     end
 
-    attr_reader :name, :type, :options
+    # Common Fields
+    attr_reader :name, :type, :options, :flags, :justification, :value, :valuedefault
   end
 end

--- a/test/field_test.rb
+++ b/test/field_test.rb
@@ -11,7 +11,7 @@ class FieldTest < Test::Unit::TestCase
 FieldType: Choice
 FieldName: SomeChoiceField
 FieldFlags: 71696384
-FieldValue:  
+FieldValue: Abc123
 FieldValueDefault:  
 FieldJustification: Left
 FieldStateOption:  
@@ -24,6 +24,24 @@ END
     assert_equal 'Choice', f.type
     assert_equal 'SomeChoiceField', f.name
     assert_equal ['', '010 Foo Bar', 'Another option (xyz)'], f.options
+
+    assert_equal "Abc123", f.value
+    assert_equal "", f.valuedefault
+    assert_equal "Left", f.justification
+    assert_equal "71696384", f.flags
+  end
+
+
+  UNKNOWN_FIELD = <<-END
+FieldType: Choice
+FieldFoo: FooTown
+FieldBar: BarTown
+END
+
+  def test_generate_new_field_key_accessors_on_the_fly
+    f = PdfForms::Field.new UNKNOWN_FIELD
+    assert_equal 'FooTown', f.foo
+    assert_equal 'BarTown', f.bar
   end
 
 end


### PR DESCRIPTION
Wanted to use this library in our apps tests for examining pdf field values.  The Field object was limited to a pre-defined set of fields.  I added additional common field attributes and support for handling non-pre-defined or unknown field attributes.  If a field attribute is unknown, a method is created for the ruby-ized field name and it's value set.  Names simply have the Field prefix removed and are downcased i.e. FieldFlags becomes flags.

Thanks for releasing this library.
