### PR TITLE
Revert behavior for encrypt options when no password is specified.  

### DIFF
--- a/lib/pdf_forms/pdftk_wrapper.rb
+++ b/lib/pdf_forms/pdftk_wrapper.rb
@@ -27,6 +27,7 @@ module PdfForms
       tmp = Tempfile.new('pdf_forms-fdf')
       tmp.close
       fdf.save_to tmp.path
+      fill_options = {:tmp_path => tmp.path}.merge(fill_options)
       command = pdftk_command q_template, 'fill_form', safe_path(tmp.path), 'output', q_destination, add_options(fill_options)
       output = %x{#{command}}
       unless File.readable?(destination) && File.size(destination) > 0
@@ -101,6 +102,7 @@ module PdfForms
       end
       if option_or_global(:encrypt, local_options)
         encrypt_pass = option_or_global(:encrypt_password, local_options)
+        encrypt_pass ||= option_or_global(:tmp_path, local_options)
         encrypt_options = option_or_global(:encrypt_options, local_options)
         opt_args.concat ['encrypt_128bit', 'owner_pw', encrypt_pass, encrypt_options]
       end

--- a/test/pdftk_wrapper_test.rb
+++ b/test/pdftk_wrapper_test.rb
@@ -7,6 +7,7 @@ class PdftkWrapperTest < Test::Unit::TestCase
     @pdftk = PdfForms.new 'pdftk', :data_format => data_format
     @pdftk_utf8 = PdfForms.new 'pdftk', utf8_fields: true
     @pdftk_options = PdfForms.new 'pdftk', :flatten => true, :encrypt => true, :data_format => data_format
+    @pdftk_with_encrypt_options = PdfForms.new 'pdftk', :flatten => true, :encrypt => true, :data_format => data_format, :encrypt_options => 'allow printing'
   end
 
   def test_should_check_executable
@@ -54,6 +55,12 @@ class PdftkWrapperTest < Test::Unit::TestCase
 
   def test_fill_form_encrypted_and_flattened
     @pdftk_options.fill_form 'test/fixtures/form.pdf', 'output.pdf', 'program_name' => 'SOME TEXT'
+    assert File.size('output.pdf') > 0
+    FileUtils.rm 'output.pdf'
+  end
+
+  def test_fill_form_encrypted_and_flattened_with_encrypt_options
+    @pdftk_with_encrypt_options.fill_form 'test/fixtures/form.pdf', 'output.pdf', 'program_name' => 'SOME TEXT'
     assert File.size('output.pdf') > 0
     FileUtils.rm 'output.pdf'
   end


### PR DESCRIPTION
Using the temp path for the encrypt password was the behavior in 0.55, this reverts to that behvior if no password is specified.  Fixes #16
