### PR TITLE
Changed .to_str to .to_s.

### DIFF
--- a/lib/pdf_forms/normalize_path.rb
+++ b/lib/pdf_forms/normalize_path.rb
@@ -6,7 +6,7 @@ module PdfForms
 
     def normalize_path(path)
       path = path.to_path if path.respond_to? :to_path
-      path.to_str
+      path.to_s
     end
 
   end


### PR DESCRIPTION
I was having issues with the .to_str conversion. The .to_s is in every Ruby object vs .to_str is only available in objects that are more string like, i.e. Symbol, String. This way, it'll be more flexible.