### PR TITLE
Support field properties with values that have `: ` in them

### DIFF
--- a/lib/pdf_forms/field.rb
+++ b/lib/pdf_forms/field.rb
@@ -17,7 +17,7 @@ module PdfForms
           (@options ||= []) << $1
         else
           line.strip!
-          key, value = line.split(": ")
+          key, value = line.split(": ", 2)
           key.gsub!(/Field/, "")
           key = key.split(/(?=[A-Z])/).map(&:downcase).join('_').split(":")[0]
           

--- a/test/field_test.rb
+++ b/test/field_test.rb
@@ -50,5 +50,15 @@ END
     assert_equal 'BarTown', f.bar
   end
 
-end
+  VALUE_WITH_COLON = <<-END
+FieldType: Text
+FieldName: Date
+FieldNameAlt: Date: most recent
+END
 
+  def test_field_values_with_colons
+    f = PdfForms::Field.new VALUE_WITH_COLON
+    assert_equal 'Date: most recent', f.name_alt
+  end
+
+end


### PR DESCRIPTION
This is a pretty simple change for cases where field properties have the string ": " in them—it just ensures the line is only split one time on ": ", since everything after the first ": " should be the value.

Fixes #48.