### PR TITLE
Read text field with multiple lines

### DIFF
--- a/lib/pdf_forms/field.rb
+++ b/lib/pdf_forms/field.rb
@@ -19,8 +19,7 @@ module PdfForms
         else
           line.strip!
           key, value = line.split(": ", 2)
-          if not key then key = "" end           # ignore key if line doesn't have a ': '
-          if key.gsub!(/Field/, "")
+          if key and key.gsub!(/Field/, "")
             key = key.split(/(?=[A-Z])/).map(&:downcase).join('_').split(":")[0]
 
             instance_variable_set("@#{key}", value)

--- a/test/field_test.rb
+++ b/test/field_test.rb
@@ -61,4 +61,25 @@ END
     assert_equal 'Date: most recent', f.name_alt
   end
 
+MULTILINE_TEXT_VALUE = <<-END
+1. First element of my list;
+2. Second element of my list;
+3. Third element of my list.
+
+This is my list.
+END
+MULTILINE_TEXT_FIELD = <<-END
+FieldType: Text
+FieldName: minhalista
+FieldFlags: 4096
+FieldValue: #{MULTILINE_TEXT_VALUE}
+FieldJustification: Left
+END
+
+  def test_text_field_with_multiple_lines
+    f = PdfForms::Field.new MULTILINE_TEXT_FIELD
+    assert_equal MULTILINE_TEXT_VALUE, f.value
+  end
+
+
 end


### PR DESCRIPTION
Changes the way the parse field occurs,
so that we can read a pdf with text fields with multiple lines.