### PR TITLE
Additional FDF data format with better support for accented characters

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ require 'pdf_forms'
 # add :data_format => 'XFdf' option to generate XFDF instead of FDF when
 # filling a form (XFDF is supposed to have better support for non-western
 # encodings)
+# add :data_format => 'FdfHex' option to generate FDF with values passed in
+# UTF16 hexadecimal format (Hexadecimal format has also proven more reliable
+# for passing latin accented characters to pdftk)
 # add :utf8_fields => true in order to get UTF8 encoded field metadata (this
 # will use dump_data_fields_utf8 instead of dump_data_fields in the call to
 # pdftk)

--- a/lib/pdf_forms.rb
+++ b/lib/pdf_forms.rb
@@ -5,6 +5,7 @@ require 'pdf_forms/normalize_path'
 require 'pdf_forms/data_format'
 require 'pdf_forms/fdf'
 require 'pdf_forms/xfdf'
+require 'pdf_forms/fdf_hex'
 require 'pdf_forms/pdf'
 require 'pdf_forms/pdftk_wrapper'
 

--- a/lib/pdf_forms/fdf_hex.rb
+++ b/lib/pdf_forms/fdf_hex.rb
@@ -25,7 +25,7 @@ module PdfForms
 
     def encode_value_as_hex(value)
       value = value.to_s
-      utf_16 = value.encode!('UTF-16BE', :invalid => :replace, :undef => :replace)
+      utf_16 = value.encode('UTF-16BE', :invalid => :replace, :undef => :replace)
       '<FEFF' + utf_16.unpack('H*').first.upcase + '>'
     end
   end

--- a/lib/pdf_forms/fdf_hex.rb
+++ b/lib/pdf_forms/fdf_hex.rb
@@ -24,6 +24,7 @@ module PdfForms
     end
 
     def encode_value_as_hex(value)
+      value = value.to_s
       utf_16 = value.encode!('UTF-16BE', :invalid => :replace, :undef => :replace)
       '<FEFF' + utf_16.unpack('H*').first.upcase + '>'
     end

--- a/lib/pdf_forms/fdf_hex.rb
+++ b/lib/pdf_forms/fdf_hex.rb
@@ -1,0 +1,31 @@
+# coding: UTF-8
+
+module PdfForms
+  # Map keys and values to Adobe's FDF format.
+  #
+  # This is a variation of the original Fdf data format, values are encoded in UTF16 hexadesimal
+  # notation to improve compatibility with non ascii charsets.
+  #
+  # Information about hexadesimal FDF values was found here:
+  #
+  # http://stackoverflow.com/questions/6047970/weird-characters-when-filling-pdf-with-pdftk
+  #
+  class FdfHex < Fdf
+    private
+
+    def field(key, value)
+      "<</T(#{key})/V" +
+        (Array === value ? encode_many(value) : encode_value_as_hex(value)) +
+        ">>\n"
+    end
+
+    def encode_many(values)
+      "[#{values.map { |v| encode_value_as_hex(v) }.join}]"
+    end
+
+    def encode_value_as_hex(value)
+      utf_16 = value.encode!('UTF-16BE', :invalid => :replace, :undef => :replace)
+      '<FEFF' + utf_16.unpack('H*').first.upcase + '>'
+    end
+  end
+end

--- a/test/fdf_hex_test.rb
+++ b/test/fdf_hex_test.rb
@@ -1,0 +1,23 @@
+# coding: UTF-8
+
+require 'test_helper'
+
+# utf16 hex representation:
+# foo: 0066006F006F
+# bar: 006200610072
+# qux: 007100750078
+
+class FdfHexTest < Minitest::Test
+  def test_fdf_generation
+    fdf = PdfForms::FdfHex.new :field1 => 'foo', :other_field => 'bar qux'
+    assert fdf_text = fdf.to_fdf
+    assert_match %r{<</T\(field1\)/V<FEFF0066006F006F>>>}, fdf_text
+    assert_match %r{<</T\(other_field\)/V<FEFF0062006100720020007100750078>>>}, fdf_text
+  end
+
+  def test_multival
+    fdf = PdfForms::FdfHex.new :field1 => %w(foo bar)
+    assert fdf_text = fdf.to_fdf
+    assert_match '<</T(field1)/V[<FEFF0066006F006F><FEFF006200610072>]>>', fdf_text
+  end
+end

--- a/test/fdf_hex_test.rb
+++ b/test/fdf_hex_test.rb
@@ -20,4 +20,10 @@ class FdfHexTest < Minitest::Test
     assert fdf_text = fdf.to_fdf
     assert_match '<</T(field1)/V[<FEFF0066006F006F><FEFF006200610072>]>>', fdf_text
   end
+
+  def test_nil
+    fdf = PdfForms::FdfHex.new :field1 => nil
+    assert fdf_text = fdf.to_fdf
+    assert_match '<</T(field1)/V<FEFF>>>', fdf_text
+  end
 end


### PR DESCRIPTION
Hi there!

I was having problems feeding accented characters to pdf using the existing data formats. Poking around I found this:

http://stackoverflow.com/questions/6047970/weird-characters-when-filling-pdf-with-pdftk

Apparently some characters above U+00FF can only get through using the UTF16 hexadecimal  notation. So for example, the value "foo" renders as `<FEFF0066006F006F>`.

This PR implements an additional data format that inherits from `PdfForms::Fdf` and renders values using the above notation.

This is related to #57.
