### PR TITLE
Feature: Support `replacement_font` flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,9 @@ pdftk.fill_form '/path/to/form.pdf', 'myform.pdf', {foo: 'bar'}, encrypt: true, 
 
 # you can also protect the PDF even from opening by specifying an additional user_pw option:
 pdftk.fill_form '/path/to/form.pdf', 'myform.pdf', {foo: 'bar'}, encrypt: true, encrypt_options: 'user_pw secret'
+
+# if you are facing font issues with your pdf, you can specify :replacement_font option:
+pdftk.fill_form '/path/to/form.pdf', 'myform.pdf', {foo: 'bar'}, replacement_font: '/path/to/font'
 ```
 
 Any options shown above can also be set when initializing the PdfForms
@@ -103,7 +106,8 @@ In case your form's field names contain HTML entities (like
 
 ### Non-ASCII Characters (UTF8 etc) are not displayed in the filled out PDF
 
-First, check if the field value has been stored properly in the output PDF using `pdftk output.pdf dump_data_fields_utf8`.
+First, try to use the `replacement_font` option and specify the font that's not being displayed.
+If it doesn't work, check if the field value has been stored properly in the output PDF using `pdftk output.pdf dump_data_fields_utf8`.
 
 If it has been stored but is not rendered, your input PDF lacks the proper font for your kind of characters. Re-create it and embed any necessary fonts.
 If the value has not been stored, there is a problem with filling out the form, either on your side, of with this gem.

--- a/lib/pdf_forms/pdftk_wrapper.rb
+++ b/lib/pdf_forms/pdftk_wrapper.rb
@@ -158,6 +158,9 @@ module PdfForms
         encrypt_options = encrypt_options.split if String === encrypt_options
         args << ['encrypt_128bit', 'owner_pw', encrypt_pass, encrypt_options]
       end
+      if option_or_global(:replacement_font, local_options)
+        args << ['replacement_font', option_or_global(:replacement_font, local_options)]
+      end
       args.flatten!
       args.compact!
       args


### PR DESCRIPTION
Closes https://github.com/jkraemer/pdf-forms/issues/88

## What happened 👀

It allows a new option `replacement_font`

## Insight 📝

To use this option, simply pass the font directory:

```ruby
replacement_font: '/path/to/font'
```

## Proof Of Work 📹

File Changes