### PR TITLE
Escape double quotes in field names when generating XFDF

### DIFF
--- a/lib/pdf_forms/xfdf.rb
+++ b/lib/pdf_forms/xfdf.rb
@@ -19,15 +19,19 @@ module PdfForms
       REXML::Text.new(value.to_s).to_s
     end
 
+    def escape(value)
+      Array(value).map{ |v| quote(v) }.join(" ")
+    end
+
     def header
       '<?xml version="1.0" encoding="UTF-8"?>
         <xfdf xmlns="http://ns.adobe.com/xfdf/" xml:space="preserve">
           <fields>
       '
     end
-
+    
     def field(key, value)
-      "<field name=\"#{key}\"><value>#{Array(value).map{ |v| quote(v) }.join(" ")}</value></field>"
+      "<field name=\"#{escape(key)}\"><value>#{escape(value)}</value></field>"
     end
 
     def footer

--- a/test/xfdf_test.rb
+++ b/test/xfdf_test.rb
@@ -16,6 +16,12 @@ class XfdfTest < Minitest::Test
     assert_match %r{<field name=\"field1\"><value>some&lt;1&gt;</value></field>}, fdf_text
   end
 
+  def test_double_quotes_in_field_name
+    fdf = PdfForms::XFdf.new "field \"one\"" => 'some<1>'
+    assert fdf_text = fdf.to_fdf
+    assert_match %r{<field name=\"field &quot;one&quot;\"><value>some&lt;1&gt;</value></field>}, fdf_text
+  end
+
   def test_multival
     fdf = PdfForms::XFdf.new :field1 => %w(one two)
     assert fdf_text = fdf.to_fdf


### PR DESCRIPTION
We had a strange PDF where some of the form fields contained double quotes in the name. The correct way to escape these in XML is by replacing the double quote characters (`"`) with `&quot;`. So I extracted the existing code for the value into a new `#escape` method, and applied the escaping to both the key and the value.

Example form data from one of our PDFs:

```
                            "L'Investisseur n'est pas un partnership" => nil,
                          "L'investisseur est une telle flow-through" => nil,
                    "d'un \"benefit plan investor\" au sens de 29 US" => nil,
                                      "aucun des cas visés ci-dessus" => nil
```

Thanks!