### PR TITLE
Fix frozen string literal issue for ruby 3.4.0 

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby-version: ['3.1', '3.0', '2.7']
+        ruby-version: ['3.3', '3.1', '2.7']
 
     steps:
       - uses: actions/checkout@v3
@@ -26,5 +26,4 @@ jobs:
       - name: Install PDFTK-Java
         run: sudo apt install -y pdftk-java
       - name: Run tests
-        run: bundle exec rake
-
+        run: RUBYOPT='--enable-frozen-string-literal --debug-frozen-string-literal' bundle exec rake

--- a/lib/pdf_forms/data_format.rb
+++ b/lib/pdf_forms/data_format.rb
@@ -15,7 +15,7 @@ module PdfForms
 
     # generate PDF content in this data format
     def to_pdf_data
-      pdf_data = header
+      pdf_data = +header
 
       @data.each do |key, value|
         if Hash === value

--- a/lib/pdf_forms/fdf.rb
+++ b/lib/pdf_forms/fdf.rb
@@ -30,7 +30,7 @@ module PdfForms
 
     # pp 559 https://www.adobe.com/content/dam/acom/en/devnet/pdf/pdfs/pdf_reference_archives/PDFReference.pdf
     def header
-      header = "%FDF-1.2\n\n1 0 obj\n<<\n/FDF << /Fields 2 0 R"
+      header = +"%FDF-1.2\n\n1 0 obj\n<<\n/FDF << /Fields 2 0 R"
 
       # /F
       header << "/F (#{options[:file]})" if options[:file]
@@ -45,7 +45,7 @@ module PdfForms
 
     # pp 561 https://www.adobe.com/content/dam/acom/en/devnet/pdf/pdfs/pdf_reference_archives/PDFReference.pdf
     def field(key, value)
-      field = "<<"
+      field = +"<<"
       field << "/T" + "(#{key})"
       field << "/V" + (Array === value ? "[#{value.map{ |v|"(#{quote(v)})" }.join}]" : "(#{quote(value)})")
       field << ">>\n"

--- a/lib/pdf_forms/pdftk_wrapper.rb
+++ b/lib/pdf_forms/pdftk_wrapper.rb
@@ -106,7 +106,7 @@ module PdfForms
     def cat(*args)
       in_files = []
       page_ranges = []
-      file_handle = "A"
+      file_handle = +"A"
       output = normalize_path args.pop
 
       args.flatten.compact.each do |in_file|


### PR DESCRIPTION
To prepare for ruby 3.4.0 and making strings frozen by default, I've stumbled upon these string mutations.

Let me know if you need anything ( I didn't add tests since I assume tests exist for this feature )

similar to https://github.com/fog/fog-aws/pull/709